### PR TITLE
feat: add bookmark slash command and application

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,19 @@
+name: Post Release to Discord
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  run_main:
+    runs-on: ubuntu-18.04
+    name: Discord Webhook
+    steps:
+      - name: Send message
+        uses: ddivad195/discord-styled-releases@main
+        with:
+          project_name: "Keeper"
+          embed_colour: "1315909"
+          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}

--- a/commands.md
+++ b/commands.md
@@ -16,6 +16,7 @@
 ## General
 | Commands | Arguments | Description                                         |
 | -------- | --------- | --------------------------------------------------- |
+| bookmark | Message   | Bookmark a message using Keeper                     |
 | delete   | Message   | Delete a Keeper bookmark by ID inside of DM channel |
 
 ## Operation

--- a/src/main/kotlin/me/ddivad/keeper/Main.kt
+++ b/src/main/kotlin/me/ddivad/keeper/Main.kt
@@ -69,7 +69,7 @@ suspend fun main() {
                     "Reaction: ${guildConfiguration.bookmarkReaction}\n" +
                     "```")
             addField("Bot Info", "```" +
-                    "Version: 1.5.0\n" +
+                    "Version: 1.6.0\n" +
                     "DiscordKt: ${it.discord.versions.library}\n" +
                     "Kord: ${it.discord.versions.kord}\n" +
                     "Kotlin: ${KotlinVersion.CURRENT}\n" +

--- a/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
+++ b/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
@@ -1,11 +1,17 @@
 package me.ddivad.keeper.commands
 
+import dev.kord.x.emoji.Emojis
+import dev.kord.x.emoji.addReaction
+import me.ddivad.keeper.dataclasses.Configuration
 import me.ddivad.keeper.dataclasses.Permissions
+import me.ddivad.keeper.embeds.buildSavedMessageEmbed
+import me.ddivad.keeper.services.StatisticsService
 import me.jakejmattson.discordkt.api.arguments.MessageArg
 import me.jakejmattson.discordkt.api.commands.commands
+import me.jakejmattson.discordkt.api.extensions.sendPrivateMessage
 
 @Suppress("unused")
-fun generalCommands() = commands("General") {
+fun generalCommands(configuration: Configuration, statsService: StatisticsService) = commands("General") {
     dmCommand("delete") {
         description = "Delete a Keeper bookmark by ID inside of DM channel"
         requiredPermission = Permissions.NONE
@@ -17,6 +23,19 @@ fun generalCommands() = commands("General") {
             } else {
                 respond("Can only delete messages sent by ${this.channel.kord.getSelf().mention} in direct message channels.")
             }
+        }
+    }
+
+    slash("bookmark", "Bookmark") {
+        description = "Bookmark a message using Keeper"
+        requiredPermission = Permissions.NONE
+        execute(MessageArg) {
+            val guild = guild?.asGuildOrNull() ?: return@execute
+            statsService.bookmarkAdded(guild)
+            this.author.sendPrivateMessage {
+                buildSavedMessageEmbed(args.first.asMessage(), guild)
+            }.addReaction(Emojis.x)
+            respond("Message Bookmarked ${Emojis.bookmark}")
         }
     }
 }

--- a/src/main/kotlin/me/ddivad/keeper/listeners/MessageListener.kt
+++ b/src/main/kotlin/me/ddivad/keeper/listeners/MessageListener.kt
@@ -17,7 +17,7 @@ fun onGuildMessageReactionAddEvent(configuration: Configuration, statsService: S
             val guild = guild?.asGuildOrNull() ?: return@on
             if (!configuration[guild.id.value]?.enabled!!) return@on
             if (this.emoji.name == configuration[guild.id.value]?.bookmarkReaction) {
-                statsService.bookmarkAdded(this)
+                statsService.bookmarkAdded(guild)
                 this.user.sendPrivateMessage {
                     buildSavedMessageEmbed(message.asMessage(), guild)
                 }.addReaction(Emojis.x)

--- a/src/main/kotlin/me/ddivad/keeper/services/StatisticsService.kt
+++ b/src/main/kotlin/me/ddivad/keeper/services/StatisticsService.kt
@@ -1,5 +1,6 @@
 package me.ddivad.keeper.services
 
+import dev.kord.core.entity.Guild
 import dev.kord.core.event.message.ReactionAddEvent
 import me.jakejmattson.discordkt.api.annotations.Service
 import me.ddivad.keeper.dataclasses.Configuration
@@ -17,13 +18,11 @@ class StatisticsService(private val configuration: Configuration, private val di
             _totalBookmarks = value
         }
 
-    suspend fun bookmarkAdded(event: ReactionAddEvent) {
-        event.getGuild()?.let {
-            totalBookmarks++
-            configuration.totalBookmarks++
-            configuration[it.id.value]!!.bookmarkCount++
-            configuration.save()
-        }
+    suspend fun bookmarkAdded(guild: Guild) {
+        totalBookmarks++
+        configuration.totalBookmarks++
+        configuration[guild.id.value]!!.bookmarkCount++
+        configuration.save()
     }
 
     val uptime: String


### PR DESCRIPTION
## feat: add bookmark slash command and application

- Update to latest DiscordKT snapshot.
- Add new slash command `bookmark <message>` to allow bookmarking.
- Add `Bookmark` message application that uses that new slash command from the message context menu.