### PR TITLE
fix: remove command recommendations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.*
 
 group = "me.ddivad"
-version = "1.9.0"
+version = "1.9.1"
 description = "A bot for saving useful messages to a DM by reacting to them."
 
 plugins {

--- a/src/main/kotlin/me/ddivad/keeper/Main.kt
+++ b/src/main/kotlin/me/ddivad/keeper/Main.kt
@@ -25,7 +25,7 @@ suspend fun main() {
             commandReaction = null
             mentionAsPrefix = true
             theme = Color(0x00BFFF)
-            entitySupplyStrategy = EntitySupplyStrategy.cacheWithCachingRestFallback
+            recommendCommands = false
             intents = Intents(
                 Intent.GuildMessageReactions,
                 Intent.DirectMessagesReactions


### PR DESCRIPTION
# fix: remove command recommendations

- Change `EntitySupplyStrategy` to use the default DiscordKT strategy.
- Disable command recommendations.