### PR TITLE
feat: update to discordkt 0.23.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.*
 
 group = "me.ddivad"
-version = "1.9.1"
+version = "1.9.2"
 description = "A bot for saving useful messages to a DM by reacting to them."
 
 plugins {
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("me.jakejmattson:DiscordKt:0.23.3")
+    implementation("me.jakejmattson:DiscordKt:0.23.4")
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.20")
 }
 

--- a/commands.md
+++ b/commands.md
@@ -14,13 +14,14 @@
 | setReaction | Reaction  | Set the reaction used to save messages |
 
 ## General
-| Commands | Arguments | Description                  |
-|----------|-----------|------------------------------|
-| bookmark | Message   | Bookmark this message        |
-| info     |           | View statistics about Keeper |
+| Commands | Arguments | Description            |
+|----------|-----------|------------------------|
+| bookmark | Message   | Bookmark this message  |
+| stats    |           | View Keeper statistics |
 
 ## Utility
 | Commands | Arguments | Description          |
 |----------|-----------|----------------------|
 | Help     | [Command] | Display a help menu. |
+| info     |           | Bot info for Keeper  |
 

--- a/src/main/kotlin/me/ddivad/keeper/Main.kt
+++ b/src/main/kotlin/me/ddivad/keeper/Main.kt
@@ -22,8 +22,6 @@ suspend fun main() {
         prefix { "/" }
 
         configure {
-            commandReaction = null
-            mentionAsPrefix = true
             theme = Color(0x00BFFF)
             recommendCommands = false
             intents = Intents(

--- a/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
+++ b/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
@@ -4,6 +4,7 @@ import dev.kord.rest.request.KtorRequestException
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.keeper.dataclasses.Configuration
+import me.ddivad.keeper.dataclasses.Permissions
 import me.ddivad.keeper.embeds.buildSavedMessageEmbed
 import me.ddivad.keeper.embeds.buildStatsEmbed
 import me.ddivad.keeper.services.StatisticsService
@@ -15,7 +16,7 @@ private val logger = KotlinLogging.logger { }
 
 @Suppress("unused")
 fun generalCommands(configuration: Configuration, statsService: StatisticsService) = commands("General") {
-    message("Bookmark Message", "bookmark", "Bookmark this message") {
+    message("Bookmark Message", "bookmark", "Bookmark this message", Permissions.EVERYONE) {
         val guild = guild.asGuildOrNull()
         statsService.bookmarkAdded(guild)
         try {
@@ -30,8 +31,7 @@ fun generalCommands(configuration: Configuration, statsService: StatisticsServic
         }
     }
 
-    slash("info") {
-        description = "View statistics about Keeper"
+    slash("stats", "View Keeper statistics", Permissions.EVERYONE) {
         execute {
             respondPublic {
                 buildStatsEmbed(guild, configuration, statsService)

--- a/src/main/kotlin/me/ddivad/keeper/commands/GuildConfigurationCommands.kt
+++ b/src/main/kotlin/me/ddivad/keeper/commands/GuildConfigurationCommands.kt
@@ -4,11 +4,11 @@ import me.ddivad.keeper.dataclasses.Configuration
 import me.ddivad.keeper.dataclasses.Permissions
 import me.jakejmattson.discordkt.arguments.*
 import me.jakejmattson.discordkt.commands.commands
+import me.jakejmattson.discordkt.dsl.edit
 
 @Suppress("unused")
 fun guildConfigurationCommands(configuration: Configuration) = commands("Configuration", Permissions.STAFF) {
-    slash("configure") {
-        description = "Configure a guild to use Keeper."
+    slash("configure", "Configure a guild to use Keeper.") {
         execute(UnicodeEmojiArg("Reaction", "The reaction that will be used to bookmark messages")) {
             if (configuration.hasGuildConfig(guild.id)) {
                 respond("Guild configuration already exists. To modify it use the commands to set values.")
@@ -20,8 +20,7 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Configu
         }
     }
 
-    slash("setReaction") {
-        description = "Set the reaction used to save messages"
+    slash("setReaction", "Set the reaction used to save messages") {
         execute(UnicodeEmojiArg("Reaction", "The reaction that will be used to bookmark messages")) {
             if (!configuration.hasGuildConfig(guild.id)) {
                 respond("Guild configuration does not exist. Run `/configure` first.")
@@ -29,34 +28,29 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Configu
             }
 
             val reaction = args.first
-            configuration[guild.id]?.bookmarkReaction = reaction.unicode
-            configuration.save()
+            configuration.edit { guildConfigurations[guild.id]?.bookmarkReaction = reaction.unicode }
             respondPublic("Reaction set to: $reaction")
         }
     }
 
-    slash("enable") {
-        description = "Enable the bot reactions"
+    slash("enable", "Enable the bot reactions") {
         execute {
             if (!configuration.hasGuildConfig(guild.id)) {
                 respond("Guild configuration does not exist. Run `/configure` first.")
                 return@execute
             }
-            configuration[guild.id]?.enabled = true
-            configuration.save()
+            configuration.edit { guildConfigurations[guild.id]?.enabled = true }
             respondPublic("Reactions enabled")
         }
     }
 
-    slash("disable") {
-        description = "Disable the bot reactions"
+    slash("disable", "Disable the bot reactions") {
         execute {
             if (!configuration.hasGuildConfig(guild.id)) {
                 respond("Guild configuration does not exist. Run `/configure` first.")
                 return@execute
             }
-            configuration[guild.id]?.enabled = false
-            configuration.save()
+            configuration.edit { guildConfigurations[guild.id]?.enabled = false }
             respondPublic("Reactions disabled")
         }
     }

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,5 +1,5 @@
-#Thu Aug 11 10:33:59 IST 2022
+#Sun Aug 28 10:26:49 IST 2022
 name=Keeper
 description=A bot for saving useful messages to a DM by reacting to them.
-version=1.9.0
+version=1.9.2
 url=https\://github.com/ddivad195/keeper


### PR DESCRIPTION
# feat: update to discordkt 0.23.4

Update to DiscordKT 0.23.4:
- Update instances of `configuration.save` to use the new `configuration.edit` builder instead.
- Rename `/info` to `/stats`.
- Add default permission to contexts.