### PR TITLE
feat: add message app for message reminders

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -14,10 +14,11 @@
 | setReaction | Reaction  | Set the reaction used to save messages |
 
 ## General
-| Commands | Arguments | Description            |
-|----------|-----------|------------------------|
-| bookmark | Message   | Bookmark this message  |
-| stats    |           | View Keeper statistics |
+| Commands | Arguments | Description                    |
+|----------|-----------|--------------------------------|
+| bookmark | Message   | Bookmark this message          |
+| remind   | Message   | Set a reminder about a message |
+| stats    |           | View Keeper statistics         |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/commands.md
+++ b/commands.md
@@ -17,7 +17,7 @@
 | Commands | Arguments | Description                    |
 |----------|-----------|--------------------------------|
 | bookmark | Message   | Bookmark this message          |
-| remind   | Message   | Set a reminder about a message |
+| reminder | Message   | Set a reminder about a message |
 | stats    |           | View Keeper statistics         |
 
 ## Utility

--- a/src/main/kotlin/me/ddivad/keeper/Main.kt
+++ b/src/main/kotlin/me/ddivad/keeper/Main.kt
@@ -18,7 +18,7 @@ fun main() {
     require(token != null) { "Expected the bot token as an environment variable" }
 
     bot(token) {
-       data("config/config.json") { Configuration() }
+        val configuration = data("config/config.json") { Configuration() }
 
         prefix { "/" }
 
@@ -32,6 +32,12 @@ fun main() {
         }
 
         onStart {
+            configuration.guildConfigurations.forEach { entry ->
+                logger.info { "Adding reminders for Guild ${entry.key}" }
+                entry.value.reminders.removeIf { it.endTime < System.currentTimeMillis() }
+                entry.value.reminders.forEach { it.launch(this, configuration) }
+            }
+            logger.info { "Reminders added" }
             logger.info { "Bot Ready" }
         }
     }

--- a/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
+++ b/src/main/kotlin/me/ddivad/keeper/commands/GeneralCommands.kt
@@ -1,16 +1,29 @@
 package me.ddivad.keeper.commands
 
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.Message
 import dev.kord.rest.request.KtorRequestException
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.keeper.dataclasses.Configuration
+import me.ddivad.keeper.dataclasses.MessageDetails
 import me.ddivad.keeper.dataclasses.Permissions
+import me.ddivad.keeper.dataclasses.Reminder
 import me.ddivad.keeper.embeds.buildSavedMessageEmbed
 import me.ddivad.keeper.embeds.buildStatsEmbed
 import me.ddivad.keeper.services.StatisticsService
+import me.ddivad.keeper.utilities.buildLogMessage
 import me.jakejmattson.discordkt.commands.commands
+import me.jakejmattson.discordkt.conversations.conversation
+import me.jakejmattson.discordkt.dsl.edit
+import me.jakejmattson.discordkt.extensions.TimeStamp
+import me.jakejmattson.discordkt.extensions.TimeStyle
+import me.jakejmattson.discordkt.extensions.jumpLink
 import me.jakejmattson.discordkt.extensions.sendPrivateMessage
 import mu.KotlinLogging
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger { }
 
@@ -24,10 +37,26 @@ fun generalCommands(configuration: Configuration, statsService: StatisticsServic
                 buildSavedMessageEmbed(args.first.asMessage(), guild)
             }.addReaction(Emojis.x)
             respond("Message Bookmarked ${Emojis.bookmark}")
-            logger.info { "Message Bookmarked by ${this.author.username}" }
+            logger.info { buildLogMessage(guild, "Message Bookmarked by ${this.author.username}") }
         } catch (e: KtorRequestException) {
             respond("Looks like you have DMs disabled. To bookmark messages, this needs to be enabled.")
-            logger.error { "Bookmark DM could not be sent" }
+            logger.error { buildLogMessage(guild, "Bookmark DM could not be sent") }
+        }
+    }
+
+    message("Remind Me", "reminder", "Set a reminder about a message", Permissions.EVERYONE) {
+        val guild = guild.asGuildOrNull()
+        val interactionResponse = interaction?.deferEphemeralResponse() ?: return@message
+        try {
+            interactionResponse.respond {
+                content = "Choose a time in the DM you just received and I'll remind you then!"
+            }
+            TimeConversation(configuration).createTimeConversation(guild, arg).startPrivately(discord, author)
+        } catch (e: KtorRequestException) {
+            interactionResponse.respond {
+                content = "Looks like you have DMs disabled. To add message reminders, this needs to be enabled."
+            }
+            logger.error { buildLogMessage(guild, "Message reminder could not be added") }
         }
     }
 
@@ -35,6 +64,41 @@ fun generalCommands(configuration: Configuration, statsService: StatisticsServic
         execute {
             respondPublic {
                 buildStatsEmbed(guild, configuration, statsService)
+            }
+        }
+    }
+}
+
+class TimeConversation(private val configuration: Configuration) {
+    fun createTimeConversation(guild: Guild, message: Message) = conversation {
+        if (message.jumpLink() == null) {
+            respond("Message is required")
+            return@conversation
+        }
+        val guildConfiguration = configuration[guild.id] ?: return@conversation
+
+        val time = promptSelect {
+            this.selectionCount = 1..1
+            content("Choose a reminder duration")
+            option("1hr", description = "Set a 1 hour reminder", value = "3600000")
+            option("3hr", description = "Set a 1 hour reminder", value = "10800000")
+            option("12hr", description = "Set a 12 hour reminder", value = "43200000")
+            option("24hr", description = "Set a 24 hour reminder", value = "86400000")
+            option("cancel", description = "Cancel", value = "cancel")
+        }.first()
+
+        if (time != "cancel") {
+            val endTime = Instant.now().plusMillis(time.toLong())
+            val messageDetails = MessageDetails(message.channelId, message.author?.id, message.jumpLink()!!)
+            val reminder = Reminder(user.id, guild.id, endTime.toEpochMilli(), messageDetails)
+            configuration.edit { guildConfiguration.reminders.add(reminder) }
+            reminder.launch(discord, configuration)
+            respond("Got it, I'll remind you ${TimeStamp.at(endTime, TimeStyle.RELATIVE)}")
+            logger.info {
+                buildLogMessage(
+                    guild,
+                    "Message reminder created by ${user.username} for ${TimeUnit.MILLISECONDS.toHours(time.toLong())} hours"
+                )
             }
         }
     }

--- a/src/main/kotlin/me/ddivad/keeper/commands/GuildConfigurationCommands.kt
+++ b/src/main/kotlin/me/ddivad/keeper/commands/GuildConfigurationCommands.kt
@@ -2,7 +2,7 @@ package me.ddivad.keeper.commands
 
 import me.ddivad.keeper.dataclasses.Configuration
 import me.ddivad.keeper.dataclasses.Permissions
-import me.jakejmattson.discordkt.arguments.*
+import me.jakejmattson.discordkt.arguments.UnicodeEmojiArg
 import me.jakejmattson.discordkt.commands.commands
 import me.jakejmattson.discordkt.dsl.edit
 
@@ -26,7 +26,6 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Configu
                 respond("Guild configuration does not exist. Run `/configure` first.")
                 return@execute
             }
-
             val reaction = args.first
             configuration.edit { guildConfigurations[guild.id]?.bookmarkReaction = reaction.unicode }
             respondPublic("Reaction set to: $reaction")

--- a/src/main/kotlin/me/ddivad/keeper/dataclasses/Configuration.kt
+++ b/src/main/kotlin/me/ddivad/keeper/dataclasses/Configuration.kt
@@ -2,28 +2,63 @@ package me.ddivad.keeper.dataclasses
 
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Guild
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import me.ddivad.keeper.logger
+import me.ddivad.keeper.utilities.buildLogMessage
+import me.jakejmattson.discordkt.Discord
 import me.jakejmattson.discordkt.dsl.Data
+import me.jakejmattson.discordkt.dsl.edit
+import me.jakejmattson.discordkt.extensions.sendPrivateMessage
+import mu.KotlinLogging
+
+val logger = KotlinLogging.logger {  }
 
 @Serializable
-data class Configuration(var totalBookmarks: Int = 0,
-                         val guildConfigurations: MutableMap<Snowflake, GuildConfiguration> = mutableMapOf()) : Data() {
+data class Configuration(
+    var totalBookmarks: Int = 0,
+    val guildConfigurations: MutableMap<Snowflake, GuildConfiguration> = mutableMapOf()
+) : Data() {
     operator fun get(id: Snowflake) = guildConfigurations[id]
 
     fun setup(guild: Guild, reaction: String) {
         if (guildConfigurations[guild.id] != null) return
-
         val newConfiguration = GuildConfiguration(reaction, true)
-
-        guildConfigurations[guild.id] = newConfiguration
-        save()
+        edit { guildConfigurations[guild.id] = newConfiguration }
     }
+
     fun hasGuildConfig(guildId: Snowflake) = guildConfigurations.containsKey(guildId)
 }
 
 @Serializable
 data class GuildConfiguration(
-        var bookmarkReaction: String,
-        var enabled: Boolean,
-        var bookmarkCount: Int = 0
+    var bookmarkReaction: String,
+    var enabled: Boolean,
+    var bookmarkCount: Int = 0,
+    val reminders: MutableList<Reminder> = mutableListOf()
 )
+
+@Serializable
+data class Reminder(val user: Snowflake, val guildId: Snowflake, val endTime: Long, val message: MessageDetails) {
+    fun launch(discord: Discord, configuration: Configuration) {
+        val guildConfiguration = configuration[guildId] ?: return
+        logger.debug { "Adding reminder - User: $user - Guild: $guildId, Endtime: $endTime" }
+        GlobalScope.launch {
+            delay(endTime - System.currentTimeMillis())
+            logger.debug { "Reminder triggered: $user - Guild: $guildId, Endtime: $endTime" }
+            val author = message.author?.let { discord.kord.getUser(it) }
+            val channel = discord.kord.getChannel(message.channel)
+            discord.kord.getUser(user)?.sendPrivateMessage {
+                title = "Reminder"
+                description = "You asked me to remind you about [this message](${message.link}) from ${author?.mention} in ${channel?.mention}"
+                color = discord.configuration.theme
+            }
+            configuration.edit { guildConfiguration.reminders.remove(this@Reminder) }
+        }
+    }
+}
+
+@Serializable
+data class MessageDetails(val channel: Snowflake, val author: Snowflake?, val link: String)

--- a/src/main/kotlin/me/ddivad/keeper/listeners/MessageListener.kt
+++ b/src/main/kotlin/me/ddivad/keeper/listeners/MessageListener.kt
@@ -5,8 +5,9 @@ import dev.kord.rest.request.KtorRequestException
 import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.addReaction
 import me.ddivad.keeper.dataclasses.Configuration
-import me.ddivad.keeper.services.StatisticsService
 import me.ddivad.keeper.embeds.buildSavedMessageEmbed
+import me.ddivad.keeper.services.StatisticsService
+import me.ddivad.keeper.utilities.buildLogMessage
 import me.jakejmattson.discordkt.dsl.listeners
 import me.jakejmattson.discordkt.extensions.idDescriptor
 import me.jakejmattson.discordkt.extensions.isSelf
@@ -22,7 +23,6 @@ fun onGuildMessageReactionAddEvent(configuration: Configuration, statsService: S
             val guild = guild?.asGuildOrNull() ?: return@on
             val guildConfiguration = configuration[guild.id] ?: return@on
             val msg = message.asMessageOrNull() ?: return@on
-
             if (!guildConfiguration.enabled) return@on
 
             if (this.emoji.name == configuration[guild.id]?.bookmarkReaction) {
@@ -31,9 +31,9 @@ fun onGuildMessageReactionAddEvent(configuration: Configuration, statsService: S
                     this.user.sendPrivateMessage {
                         buildSavedMessageEmbed(msg, guild)
                     }.addReaction(Emojis.x)
-                    logger.info { "${guild.name} (${guild.id}): Message Bookmarked by ${msg.author?.username}" }
+                    logger.info { buildLogMessage(guild, "Message Bookmarked by ${msg.author?.username}") }
                 } catch (e: KtorRequestException) {
-                    logger.error { "${guild.name} (${guild.id}): Bookmark DM could not be sent" }
+                    logger.error { buildLogMessage(guild, "Bookmark DM could not be sent") }
                 }
             }
         } else {

--- a/src/main/kotlin/me/ddivad/keeper/utilities/LoggerUtils.kt
+++ b/src/main/kotlin/me/ddivad/keeper/utilities/LoggerUtils.kt
@@ -1,0 +1,6 @@
+package me.ddivad.keeper.utilities
+
+import dev.kord.core.entity.Guild
+
+fun buildLogMessage(guild: Guild, message: String) =
+    "${guild.name} (${guild.id}): $message"

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Thu Sep 08 22:12:14 IST 2022
+#Thu Sep 15 13:13:39 IST 2022
 name=Keeper
 description=A bot for saving useful messages to a DM by reacting to them.
 version=1.9.2

--- a/src/main/resources/bot.properties
+++ b/src/main/resources/bot.properties
@@ -1,4 +1,4 @@
-#Thu Sep 15 13:13:39 IST 2022
+#Thu Sep 15 13:16:14 IST 2022
 name=Keeper
 description=A bot for saving useful messages to a DM by reacting to them.
 version=1.9.2


### PR DESCRIPTION
# feat: add message app for message reminders

Add reminders to Keeper.
- Added new `/reminder` command with "Remind Me" message context.
- Udated logging.